### PR TITLE
Add update_position overload

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -67,6 +67,14 @@ PYBIND11_MODULE(rmf_adapter, m) {
              py::call_guard<py::scoped_ostream_redirect,
                             py::scoped_estream_redirect>())
         .def("update_position",
+             py::overload_cast<const Eigen::Vector3d&,
+                               std::size_t>(
+                 &agv::RobotUpdateHandle::update_position),
+             py::arg("position"),
+             py::arg("target_waypoint"),
+             py::call_guard<py::scoped_ostream_redirect,
+                            py::scoped_estream_redirect>())
+        .def("update_position",
              py::overload_cast<const std::string&,
                                const Eigen::Vector3d&,
                                const double,


### PR DESCRIPTION
The `RobotUpdateHandle` had an additional `update_position()` method overload during the development of the Python bindings that got missed.

This PR adds that.