### PR TITLE
Add additional bindings (compute_plan_starts, rmf_utils::optional constructors, and Delivery msg properties)

### DIFF
--- a/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
+++ b/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
@@ -275,12 +275,17 @@ class MockRobotCommand(adpt.RobotCommandHandle):
                     print(type(lane.entry.event))
                     print("EVENT EXECUTE FOR LANE", i, "NOT IMPLEMENTED")
 
+        print("Registered Docks:", self.dock_to_wp, "\n")
+
     def follow_new_path(self,
                         waypoints,
                         next_arrival_estimator,  # function!
                         path_finished_callback):
         print("\n[RobotCommandHandle] Setting new path of %d waypoints..."
               % len(waypoints))
+        print("Waypoints:", [x.graph_index.value for x in waypoints])
+
+        self.stop()
 
         self.current_waypoint_target = 0
         self.active = True
@@ -293,8 +298,12 @@ class MockRobotCommand(adpt.RobotCommandHandle):
         )
 
     def stop(self):
-        self.timer.reset()
-        self.timer.cancel()
+        try:
+            self.timer.reset()
+            self.timer.cancel()
+        except Exception:
+            # For when a timer does not exist yet
+            pass
 
     def dock(self, dock_name, docking_finished_callback):
         assert dock_name in self.dock_to_wp

--- a/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
+++ b/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
@@ -557,6 +557,12 @@ def main():
 
     assert len(robot_cmd.visited_waypoints) == 6
     assert all([x in robot_cmd.visited_waypoints for x in [0, 5, 6, 7, 8, 10]])
+    assert robot_cmd.visited_waypoints[0] == 2
+    assert robot_cmd.visited_waypoints[5] == 4
+    assert robot_cmd.visited_waypoints[6] == 3
+    assert robot_cmd.visited_waypoints[7] == 1
+    assert robot_cmd.visited_waypoints[8] == 2
+    assert robot_cmd.visited_waypoints[10] == 1
     assert at_least_one_incomplete
 
     # Uncomment this to send a second request.

--- a/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
+++ b/rmf_fleet_adapter_python/scripts/rmf_fleet_adapter_python/test_adapter.py
@@ -447,6 +447,15 @@ def main():
 
     cmd_node = Node("RobotCommandHandle")
 
+    # Test compute_plan_starts, which tries to place the robot on the navgraph
+    # Your robot MUST be near a waypoint or lane for this to work though!
+    starts = plan.compute_plan_starts(test_graph,
+                                      "test_map",
+                                      [[-10.0], [0.0], [0.0]],
+                                      adapter.now())
+    assert [x.waypoint for x in starts] == [3], [x.waypoint for x in starts]
+
+    # Alternatively, if you DO know where your robot is, place it directly!
     starts = [plan.Start(adapter.now(),
                          0,
                          0.0)]

--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -164,8 +164,7 @@ PYBIND11_MODULE(rmf_adapter, m) {
                                py::overload_cast<>(
                                    &agv::test::MockAdapter::node))
         .def("request_delivery", &agv::test::MockAdapter::request_delivery)
-        .def("start",
-            &agv::test::MockAdapter::start)
+        .def("start", &agv::test::MockAdapter::start)
         .def("stop", &agv::test::MockAdapter::stop)
         .def("now", [&](agv::test::MockAdapter& self) {
             return TimePoint(rmf_traffic_ros2::convert(self.node()->now())

--- a/rmf_fleet_adapter_python/src/planner/planner.cpp
+++ b/rmf_fleet_adapter_python/src/planner/planner.cpp
@@ -76,6 +76,39 @@ void bind_plan(py::module &m) {
                     py::overload_cast<rmf_utils::optional<std::size_t> >(
                         &Start::lane));
 
+  // Rebound signature for compute_plan_starts
+  m_plan.def("compute_plan_starts",
+             [&](const rmf_traffic::agv::Graph& graph,
+                 const std::string& map_name,
+                 const Eigen::Vector3d pose,
+                 TimePoint start_time,
+                 const double max_merge_waypoint_distance,
+                 const double max_merge_lane_distance,
+                 const double min_lane_length) {
+                   using TimePointSteadyClock =
+                       std::chrono::time_point<std::chrono::steady_clock,
+                                               std::chrono::nanoseconds>;
+
+                   return rmf_traffic::agv::compute_plan_starts(
+                       graph,
+                       map_name,
+                       pose,
+                       TimePointSteadyClock(start_time.time_since_epoch()),
+                       max_merge_waypoint_distance,
+                       max_merge_lane_distance,
+                       min_lane_length
+                   );
+             },
+             py::arg("navigation_graph"),
+             py::arg("map_name"),
+             py::arg("position"),
+             py::arg("start_time"),
+             py::arg("max_merge_waypoint_distance") = 0.1,
+             py::arg("max_merge_lane_distance") = 1.0,
+             py::arg("min_lane_length") = 1e-8,
+             py::call_guard<py::scoped_ostream_redirect,
+                            py::scoped_estream_redirect>());
+
   // PLAN ======================================================================
   py::class_<Plan>(m_plan, "Plan")
       // Private constructor

--- a/rmf_fleet_adapter_python/src/types/types.cpp
+++ b/rmf_fleet_adapter_python/src/types/types.cpp
@@ -77,33 +77,33 @@ void bind_types(py::module &m) {
            py::arg("dropoff_place_name") = "",
            py::arg("dropoff_dispenser") = "")
       .def_property("task_id",
-                    [](rmf_task_msgs::msg::Delivery& self){
+                    [&](rmf_task_msgs::msg::Delivery& self){
                         return self.task_id;},
-                    [](rmf_task_msgs::msg::Delivery& self,
+                    [&](rmf_task_msgs::msg::Delivery& self,
                        std::string task_id){
                         self.task_id = task_id;})
       .def_property("pickup_place_name",
-                    [](rmf_task_msgs::msg::Delivery& self){
+                    [&](rmf_task_msgs::msg::Delivery& self){
                         return self.pickup_place_name;},
-                    [](rmf_task_msgs::msg::Delivery& self,
+                    [&](rmf_task_msgs::msg::Delivery& self,
                        std::string pickup_place_name){
                         self.pickup_place_name = pickup_place_name;})
       .def_property("pickup_dispenser",
-                    [](rmf_task_msgs::msg::Delivery& self){
+                    [&](rmf_task_msgs::msg::Delivery& self){
                         return self.pickup_dispenser;},
-                    [](rmf_task_msgs::msg::Delivery& self,
+                    [&](rmf_task_msgs::msg::Delivery& self,
                        std::string pickup_dispenser){
                         self.pickup_dispenser = pickup_dispenser;})
       .def_property("dropoff_place_name",
-                    [](rmf_task_msgs::msg::Delivery& self){
+                    [&](rmf_task_msgs::msg::Delivery& self){
                         return self.dropoff_place_name;},
-                    [](rmf_task_msgs::msg::Delivery& self,
+                    [&](rmf_task_msgs::msg::Delivery& self,
                        std::string dropoff_place_name){
                         self.dropoff_place_name = dropoff_place_name;})
       .def_property("dropoff_dispenser",
-                    [](rmf_task_msgs::msg::Delivery& self){
+                    [&](rmf_task_msgs::msg::Delivery& self){
                         return self.dropoff_dispenser;},
-                    [](rmf_task_msgs::msg::Delivery& self,
+                    [&](rmf_task_msgs::msg::Delivery& self,
                        std::string dropoff_dispenser){
                         self.dropoff_dispenser = dropoff_dispenser;});
                               // .def_property("pickup_place_name",

--- a/rmf_fleet_adapter_python/src/types/types.cpp
+++ b/rmf_fleet_adapter_python/src/types/types.cpp
@@ -46,24 +46,28 @@ void bind_types(py::module &m) {
     .def("__call__", &std::mt19937::operator());
 
   py::class_<rmf_utils::optional<std::size_t> >(m_type, "OptionalULong")
+      .def(py::init<std::size_t>())
       .def_property_readonly("has_value",
                              &rmf_utils::optional<std::size_t>::has_value)
       .def_property_readonly("value", py::overload_cast<>(
           &rmf_utils::optional<std::size_t>::value));
 
   py::class_<rmf_utils::optional<double> >(m_type, "OptionalDouble")
+      .def(py::init<double>())
       .def_property_readonly("has_value",
                              &rmf_utils::optional<double>::has_value)
       .def_property_readonly("value", py::overload_cast<>(
           &rmf_utils::optional<double>::value));
 
   py::class_<rmf_utils::optional<Eigen::Vector2d> >(m_type, "OptionalVector2D")
+      .def(py::init<Eigen::Vector2d>())
       .def_property_readonly("has_value",
                              &rmf_utils::optional<Eigen::Vector2d>::has_value)
       .def_property_readonly("value", py::overload_cast<>(
           &rmf_utils::optional<Eigen::Vector2d>::value));
 
-  py::class_<rmf_utils::nullopt_t>(m_type, "NullOptional");
+  py::class_<rmf_utils::nullopt_t>(m_type, "NullOptional")
+      .def(py::init<>());
 
   py::class_<rmf_task_msgs::msg::Delivery>(m_type, "CPPDeliveryMsg")
       .def(py::init(&make_delivery_msg),
@@ -71,5 +75,36 @@ void bind_types(py::module &m) {
            py::arg("pickup_place_name") = "",
            py::arg("pickup_dispenser") = "",
            py::arg("dropoff_place_name") = "",
-           py::arg("dropoff_dispenser") = "");
+           py::arg("dropoff_dispenser") = "")
+      .def_property("task_id",
+                    [](rmf_task_msgs::msg::Delivery& self){
+                        return self.task_id;},
+                    [](rmf_task_msgs::msg::Delivery& self,
+                       std::string task_id){
+                        self.task_id = task_id;})
+      .def_property("pickup_place_name",
+                    [](rmf_task_msgs::msg::Delivery& self){
+                        return self.pickup_place_name;},
+                    [](rmf_task_msgs::msg::Delivery& self,
+                       std::string pickup_place_name){
+                        self.pickup_place_name = pickup_place_name;})
+      .def_property("pickup_dispenser",
+                    [](rmf_task_msgs::msg::Delivery& self){
+                        return self.pickup_dispenser;},
+                    [](rmf_task_msgs::msg::Delivery& self,
+                       std::string pickup_dispenser){
+                        self.pickup_dispenser = pickup_dispenser;})
+      .def_property("dropoff_place_name",
+                    [](rmf_task_msgs::msg::Delivery& self){
+                        return self.dropoff_place_name;},
+                    [](rmf_task_msgs::msg::Delivery& self,
+                       std::string dropoff_place_name){
+                        self.dropoff_place_name = dropoff_place_name;})
+      .def_property("dropoff_dispenser",
+                    [](rmf_task_msgs::msg::Delivery& self){
+                        return self.dropoff_dispenser;},
+                    [](rmf_task_msgs::msg::Delivery& self,
+                       std::string dropoff_dispenser){
+                        self.dropoff_dispenser = dropoff_dispenser;});
+                              // .def_property("pickup_place_name",
 }

--- a/rmf_fleet_adapter_python/tests/unit/test_types.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_types.py
@@ -1,0 +1,42 @@
+import rmf_adapter.type as types
+import numpy as np
+
+
+# TYPES ======================================================================
+def test_types():
+    # Test nullopt
+    assert types.NullOptional()
+
+    # Test CPPDeliveryMsg
+    msg = types.CPPDeliveryMsg("task",
+                               "pickup_place",
+                               "pickup_dispenser",
+                               "dropoff_place",
+                               "dropoff_dispenser")
+    assert msg.task_id == "task"
+    assert msg.pickup_place_name == "pickup_place"
+    assert msg.pickup_dispenser == "pickup_dispenser"
+    assert msg.dropoff_place_name == "dropoff_place"
+    assert msg.dropoff_dispenser == "dropoff_dispenser"
+
+    msg.task_id += "_rawr"
+    msg.pickup_place_name += "_rawr"
+    msg.pickup_dispenser += "_rawr"
+    msg.dropoff_place_name += "_rawr"
+    msg.dropoff_dispenser += "_rawr"
+
+    assert msg.task_id == "task_rawr"
+    assert msg.pickup_place_name == "pickup_place_rawr"
+    assert msg.pickup_dispenser == "pickup_dispenser_rawr"
+    assert msg.dropoff_place_name == "dropoff_place_rawr"
+    assert msg.dropoff_dispenser == "dropoff_dispenser_rawr"
+
+    # Test optionals
+    assert types.OptionalULong(1).value == 1
+
+    assert types.OptionalDouble(1).value == 1
+    assert types.OptionalDouble(1.0).value == 1
+
+    assert np.ndarray.all(
+        types.OptionalVector2D([1, 2]).value == np.array([1, 2])
+    )


### PR DESCRIPTION
Implements more bindings:
- `Plan::compute_plan_starts`: For finding a robot's position on the navgraph with just its Vector3D position
- All instantiated `rmf_utils::optional` constructors: (`Double`, `ULong`, `Vector2D`, `nullopt`)
- Getters and setters for the bound `rmf_task_msgs::msg::Delivery`

Also implements unit tests for the new bound types capabilities (`rmf_utils::optional`, `rmf_task_msgs::msg::Delivery`)
And integrates the new bound `compute_plan_starts()` into the integration test `test_adapter.py`.

## Misc.
- Fixed some styling issues and added more clarifying printouts in the integration test `test_adapter.py`
- Fixed a multi-timer bug in the integration test that was causing the first waypoint visited at each start to be stuck at the 
  first waypoint of the previous timer.

## Run Tests
Integration test:
`ros2 run rmf_fleet_adapter_python test_adapter`

Unit tests (I added a new one for newly bound type constructors):
`colcon test --packages-select rmf_fleet_adapter_python --event-handlers console_direct+`