### PR TITLE
Bugfix: update adapter binding

### DIFF
--- a/rmf_fleet_adapter_python/src/adapter.cpp
+++ b/rmf_fleet_adapter_python/src/adapter.cpp
@@ -131,7 +131,8 @@ PYBIND11_MODULE(rmf_adapter, m) {
         .def_static("make", &agv::Adapter::make,
              py::arg("node_name"),
              py::arg("node_options") = rclcpp::NodeOptions(),
-             py::arg("wait_time") = std::chrono::minutes(1),
+             py::arg("wait_time") = rmf_utils::optional<rmf_traffic::Duration>(
+                 rmf_utils::nullopt),
              py::call_guard<py::scoped_ostream_redirect,
                             py::scoped_estream_redirect>())
         .def("add_fleet", &agv::Adapter::add_fleet,

--- a/rmf_fleet_adapter_python/src/types/types.cpp
+++ b/rmf_fleet_adapter_python/src/types/types.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
 #include <pybind11/eigen.h>
+#include <pybind11/chrono.h>
 
 #include <memory>
 #include <random>
@@ -8,6 +9,7 @@
 #include <rmf_utils/impl_ptr.hpp>
 #include <rmf_utils/clone_ptr.hpp>
 #include <rmf_utils/optional.hpp>
+#include <rmf_traffic/Time.hpp>
 
 #include <rmf_task_msgs/msg/delivery.hpp>
 
@@ -31,6 +33,8 @@ rmf_task_msgs::msg::Delivery make_delivery_msg(
 
   return request;
 }
+
+using Duration = rmf_traffic::Duration;
 
 void bind_types(py::module &m) {
   auto m_type = m.def_submodule("type");
@@ -65,6 +69,13 @@ void bind_types(py::module &m) {
                              &rmf_utils::optional<Eigen::Vector2d>::has_value)
       .def_property_readonly("value", py::overload_cast<>(
           &rmf_utils::optional<Eigen::Vector2d>::value));
+
+  py::class_<rmf_utils::optional<Duration> >(m_type, "OptionalDuration")
+      .def(py::init<Duration>())
+      .def_property_readonly("has_value",
+                             &rmf_utils::optional<Duration>::has_value)
+      .def_property_readonly("value", py::overload_cast<>(
+          &rmf_utils::optional<Duration>::value));
 
   py::class_<rmf_utils::nullopt_t>(m_type, "NullOptional")
       .def(py::init<>());

--- a/rmf_fleet_adapter_python/tests/unit/test_types.py
+++ b/rmf_fleet_adapter_python/tests/unit/test_types.py
@@ -1,5 +1,6 @@
 import rmf_adapter.type as types
 import numpy as np
+import datetime
 
 
 # TYPES ======================================================================
@@ -40,3 +41,5 @@ def test_types():
     assert np.ndarray.all(
         types.OptionalVector2D([1, 2]).value == np.array([1, 2])
     )
+
+    assert types.OptionalDuration(datetime.timedelta(seconds=60))


### PR DESCRIPTION
The Python binding for the `Adapter`'s factory method was not updated. (The `rmf_traffic::Duration` arg was replaced with a corresponding `rmf_utils::optional` arg.)

This PR implements the corresponding Duration optional with tests, and updates the `Adapter` binding accordingly.