### PR TITLE
Fix lambda capture bug

### DIFF
--- a/rmf_fleet_adapter_python/src/tests.cpp
+++ b/rmf_fleet_adapter_python/src/tests.cpp
@@ -20,7 +20,7 @@ void bind_tests(py::module &m) {
   m.def("test_shared_ptr",
         [](std::shared_ptr<agv::RobotCommandHandle> handle,
            std::string print_str = "DUMMY_DOCK_NAME",
-           std::function<void()> docking_finished_callback = [&](){})
+           std::function<void()> docking_finished_callback = [](){})
         {
           handle->dock(print_str, docking_finished_callback);
         },


### PR DESCRIPTION
Extremely tiny bug fix. Something broke on the shift to Foxy (the lambda now exists in non-local scope), but this fixes it.